### PR TITLE
Don’t create a redis namespace by default

### DIFF
--- a/lib/list_master.rb
+++ b/lib/list_master.rb
@@ -13,7 +13,7 @@ module ListMaster
 
   # Accepts a Redis object
   def redis=(redis)
-    @redis = Redis::Namespace.new(:list_master, redis: redis)
+    @redis = redis
   end
 
   # Returns the current Redis connection. If none has been created, create default

--- a/lib/list_master/index_methods.rb
+++ b/lib/list_master/index_methods.rb
@@ -44,8 +44,8 @@ module ListMaster
       @new_sets.each do |set|
         temp_set = "#{prefix}:#{set}"
         redis.multi do |_multi|
-          redis.persist temp_set
-          redis.rename temp_set, set
+          redis.persist(temp_set)
+          redis.rename(temp_set, set)
         end
       end
 

--- a/lib/list_master/intersect_methods.rb
+++ b/lib/list_master/intersect_methods.rb
@@ -22,7 +22,7 @@ module ListMaster
       stop_index  = limit > -1 ? start_index + limit - 1 : -1
 
       results = redis.multi do
-        redis.zinterstore output, args
+        redis.zinterstore(output, args)
         if reverse
           redis.zrevrange(output, start_index, stop_index)
         else

--- a/lib/list_master/version.rb
+++ b/lib/list_master/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ListMaster
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/spec/list_master_spec.rb
+++ b/spec/list_master_spec.rb
@@ -2,17 +2,8 @@
 
 require 'spec_helper'
 
-# rubocop:disable RSpec/MultipleExpectations
 describe ListMaster do
   describe '#redis' do
-    it 'returns a redis namespace' do
-      expect(described_class.redis.class).to eq(Redis::Namespace)
-      described_class.redis.ping.should_not be_empty
-
-      described_class.redis.set('foo', 'bar')
-      expect(described_class.redis.get('foo')).to eq('bar')
-    end
-
     it 'uses the class as the namespace for redis by default' do
       stub_const('ExampleListMaster', described_class.define {})
       expect(ExampleListMaster.redis.namespace).to eq('example_list_master')
@@ -39,4 +30,3 @@ describe ListMaster do
     end
   end
 end
-# rubocop:enable RSpec/MultipleExpectations

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,10 +15,10 @@ RSpec.configure do |config|
   config.include Support
 
   config.before do
-    ListMaster.redis.redis.flushdb
+    ListMaster.redis.flushdb
   end
 
   config.after(:suite) do
-    ListMaster.redis.redis.flushdb
+    ListMaster.redis.flushdb
   end
 end


### PR DESCRIPTION
Let the client pass in a namespaced connection if they want, so that the client can set it. That way if the client is using redis cluster they can specify a clustered hash key for the namespace.